### PR TITLE
Optimizations

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -2,3 +2,4 @@ Config = {}
 
 Config.Enable = true
 Config.WaitTime = 0
+Config.PlayersRefreshTime = 500 -- 100 is a safe lowend, going lower will increase resource use, but will work. (slower the more resources it saves)

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,11 +1,41 @@
 Blips = {}
 CurrentPlayers = {}
+appready = false
+
+function clear_blips()
+    for k, _ in pairs(Blips) do -- Loop through current map blips
+        if CurrentPlayers[tostring(k)] == nil then -- Check if the key still exists in current users
+            RemoveBlip(Blips[tostring(k)]) -- Clear Map Blip
+            Blips[tostring(k)] = nil -- Set Value to Nil
+        end
+    end
+end
+
+function GetPlayers()
+    TriggerServerEvent("mwg_playerblips:GetPlayers")
+    while next(CurrentPlayers) == nil do
+        Wait(10)
+    end
+end
+
+RegisterNetEvent("mwg_playerblips:SendPlayers", function(result)
+    CurrentPlayers = result
+end)
 
 Citizen.CreateThread(function()
     while true do
         if Config.Enable then
+            GetPlayers()
+            appready = true
+        end
+        Citizen.Wait(5000)
+    end
+end)
+
+Citizen.CreateThread(function()
+    while true do
+        if Config.Enable and appready then
             -- Get all players
-            CurrentPlayers = GetPlayers()
             local id = GetPlayerServerId(PlayerId()) -- Get Server ID of Client
             for _, player in pairs(CurrentPlayers) do
                 if tostring(id) ~= player.serverId then -- Don't create Blips for the current user
@@ -32,25 +62,3 @@ Citizen.CreateThread(function()
         Citizen.Wait(Config.WaitTime)
     end
 end)
-
-function clear_blips()
-    for k, _ in pairs(Blips) do -- Loop through current map blips
-        if CurrentPlayers[tostring(k)] == nil then -- Check if the key still exists in current users
-            RemoveBlip(Blips[tostring(k)]) -- Clear Map Blip
-            Blips[tostring(k)] = nil -- Set Value to Nil
-        end
-    end
-end
-
--- Stolen from vorp_admin
-function GetPlayers()
-    TriggerServerEvent("mwg_playerblips:GetPlayers")
-    local playersData = {}
-    RegisterNetEvent("mwg_playerblips:SendPlayers", function(result)
-        playersData = result
-    end)
-    while next(playersData) == nil do
-        Wait(10)
-    end
-    return playersData
-end


### PR DESCRIPTION
**What has changed:**
- Fixed a memory leak with next() and RegisterNet event being registered every time it looped
- Optimized drastically by breaking the getPlayers into its own thread, and a slower rate.
- Minor Optimization by only running the blip check once playerslist has been successfully received.

Prior resource was around 1.0-10ms on cpu
![image](https://user-images.githubusercontent.com/10902965/187540062-a85525e6-aeed-47cc-a0e5-02cfa0e643ed.png)

Now resource is around 0.01-0.03ms
![image](https://user-images.githubusercontent.com/10902965/187539322-4547ed5f-6d00-4c08-b5a1-11e40303a49b.png)

